### PR TITLE
Implement variadic sendCommand helper

### DIFF
--- a/src/AsyncATHandler.h
+++ b/src/AsyncATHandler.h
@@ -46,6 +46,18 @@ class AsyncATHandler {
       const String &command, String &response, const String &expectedResponse = "OK",
       uint32_t timeout = AT_DEFAULT_TIMEOUT);
 
+  template <typename... Args>
+  bool sendCommand(
+      String &response, const String &expectedResponse = "OK",
+      uint32_t timeout = AT_DEFAULT_TIMEOUT, Args &&...parts) {
+    String cmd;
+    size_t reserveSize = 0;
+    (void)std::initializer_list<int>{(reserveSize += String(parts).length(), 0)...};
+    cmd.reserve(reserveSize);
+    (void)std::initializer_list<int>{(cmd += String(parts), 0)...};
+    return sendCommand(cmd, response, expectedResponse, timeout);
+  }
+
   bool sendCommandBatch(
       const String commands[], size_t count, String responses[] = nullptr,
       uint32_t timeout = AT_DEFAULT_TIMEOUT);

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -122,6 +122,29 @@ TEST_F(AsyncATHandlerTest, SendSyncCommandWithErrorResponse) {
   log_w("--- Test End: SendSyncCommandWithErrorResponse ---");
 }
 
+TEST_F(AsyncATHandlerTest, VariadicSendCommandHelper) {
+  EXPECT_TRUE(handler->begin(*mockStream));
+  mockStream->ClearTxData();
+
+  std::thread responder([this]() {
+    WaitFor(50);
+    mockStream->InjectRxData("OK\r\n");
+  });
+
+  String response;
+  bool sendResult = handler->sendCommand(response, "OK", 1000, "AT+", "VAR");
+
+  std::string sentData;
+  WaitFor(100);
+  sentData = mockStream->GetTxData();
+
+  EXPECT_TRUE(sendResult);
+  EXPECT_EQ("AT+VAR\r\n", sentData);
+  EXPECT_EQ("OK\r\n", response);
+
+  responder.join();
+}
+
 TEST_F(AsyncATHandlerTest, UnsolicitedResponseHandling) {
   std::cout << "--- Test: UnsolicitedResponseHandling ---" << std::endl;
   log_w("--- Test Start: UnsolicitedResponseHandling ---");


### PR DESCRIPTION
## Summary
- add a variadic template overload of `sendCommand`
- test building commands from multiple pieces

## Testing
- `make format`
- `make test`
