### PR TITLE
Improve client compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
 
     - name: Setup Python
       run: |
-        apt-get update -y && apt-get install python3-pip -y
+        apt-get update -y && apt-get install python3-pip make -y
         pip install platformio
 
     - name: Run PlatformIO
-      run: pio ci  examples/basic/src/main.cpp --lib="." --board=esp32dev
+      run: make esp32

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ test: build
 	ctest --output-on-failure -j$(sysctl -n hw.ncpu) --test-dir build
 
 esp32:
+	@echo "🔨 Building for ESP32..."
+	pio ci  examples/basic/src/main.cpp --lib="." --board=esp32dev
+
+esp32-test: esp32
 	@echo "🚀 Flashing hardware test"
 	pio test -d examples/basic
 

--- a/src/AsyncATHandler.cpp
+++ b/src/AsyncATHandler.cpp
@@ -308,6 +308,12 @@ bool AsyncATHandler::sendCommand(
   }
 }
 
+bool AsyncATHandler::sendCommand(
+    const String& command, const String& expectedResponse, uint32_t timeout) {
+  String dummy;
+  return sendCommand(command, dummy, expectedResponse, timeout);
+}
+
 bool AsyncATHandler::sendCommandBatch(
     const String commands[], size_t count, String responses[], uint32_t timeout) {
   bool allSuccess = true;

--- a/src/AsyncATHandler.h
+++ b/src/AsyncATHandler.h
@@ -14,7 +14,6 @@ typedef std::function<void(const char *response)> UnsolicitedCallback;
 
 class AsyncATHandler {
  private:
-  Stream *_stream;
   TaskHandle_t readerTask;
   QueueHandle_t commandQueue;
   QueueHandle_t responseQueue;
@@ -34,6 +33,8 @@ class AsyncATHandler {
   bool isUnsolicitedResponse(const char *response);
 
  public:
+  Stream *_stream;
+
   AsyncATHandler();
   ~AsyncATHandler();
 
@@ -44,6 +45,10 @@ class AsyncATHandler {
 
   bool sendCommand(
       const String &command, String &response, const String &expectedResponse = "OK",
+      uint32_t timeout = AT_DEFAULT_TIMEOUT);
+
+  bool sendCommand(
+      const String &command, const String &expectedResponse = "OK",
       uint32_t timeout = AT_DEFAULT_TIMEOUT);
 
   template <typename... Args>

--- a/test/test_native/test_main.cpp
+++ b/test/test_native/test_main.cpp
@@ -122,6 +122,27 @@ TEST_F(AsyncATHandlerTest, SendSyncCommandWithErrorResponse) {
   log_w("--- Test End: SendSyncCommandWithErrorResponse ---");
 }
 
+TEST_F(AsyncATHandlerTest, SendCommandWithoutResponseParameter) {
+  EXPECT_TRUE(handler->begin(*mockStream));
+  mockStream->ClearTxData();
+
+  std::thread responder([this]() {
+    WaitFor(50);
+    mockStream->InjectRxData("OK\r\n");
+  });
+
+  bool sendResult = handler->sendCommand("AT", "OK", 1000);
+
+  std::string sentData;
+  WaitFor(100);
+  sentData = mockStream->GetTxData();
+
+  EXPECT_TRUE(sendResult);
+  EXPECT_EQ("AT\r\n", sentData);
+
+  responder.join();
+}
+
 TEST_F(AsyncATHandlerTest, VariadicSendCommandHelper) {
   EXPECT_TRUE(handler->begin(*mockStream));
   mockStream->ClearTxData();


### PR DESCRIPTION
- Add 'esp32-test' command.
- The `make esp32` command now builds the CI tests.
- Add `sendCommand` override with no response string required.